### PR TITLE
add fabric-api as dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,6 +37,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.15.11",
-    "minecraft": "1.21.x"
+    "minecraft": "1.21.x",
+    "fabric-api": "*"
   }
 }


### PR DESCRIPTION
Makes mod depend on any version of `fabric-api` so user-friendly fabric loading error will popup when started without fabric api
Fixes #25 