### PR TITLE
Add hypixel.net to the list of blocked domains

### DIFF
--- a/src/main/java/freelook/freelook/config/FreeLookConfig.java
+++ b/src/main/java/freelook/freelook/config/FreeLookConfig.java
@@ -22,7 +22,8 @@ public class FreeLookConfig {
 
     private List<String> blockList = new ArrayList<>(List.of(
             "play.hypixel.net",
-            "mc.hypixel.net"
+            "mc.hypixel.net",
+            "hypixel.net"
     ));
 
     public List<String> getBlockList() {


### PR DESCRIPTION
Since hypixel.net redirects you to mc.hypixel.net