### PR TITLE
Made the mod disable the Blocked Server restriction when joining a non-blocked server

### DIFF
--- a/src/main/java/freelook/freelook/FreeLookMod.java
+++ b/src/main/java/freelook/freelook/FreeLookMod.java
@@ -50,6 +50,7 @@ public class FreeLookMod implements ClientModInitializer {
             ServerData server = Minecraft.getInstance().getCurrentServer();
             if (server != null) {
                 String currentIP = server.ip.toLowerCase();
+                config.setBlocked(false);
                 for (String blocked : config.getBlockList()) {
                     if (currentIP.contains(blocked.toLowerCase())) {
                         config.setBlocked(true);


### PR DESCRIPTION


Usually the mod will lift the restriction when leaving a blocked server, but I think a mod I use (the logs refuse to tell me which one) was conflicting with that check for some reason, and having a check on join rather than on leave fixes that.