### PR TITLE
Make isBlocked transient so runtime block state isn't persisted

### DIFF
--- a/src/main/java/freelook/freelook/config/FreeLookConfig.java
+++ b/src/main/java/freelook/freelook/config/FreeLookConfig.java
@@ -19,7 +19,7 @@ public class FreeLookConfig {
     private boolean isToggle = false;
     private int perspective = 3;
     private float maxHeadYaw = 360.0f;
-    private boolean isBlocked = false;
+    private transient boolean isBlocked = false;
 
     private List<String> blockList = new ArrayList<>(List.of(
             "hypixel.net"


### PR DESCRIPTION
`isBlocked` is per-session runtime state — set true on server JOIN if the IP matches the blocklist, cleared on DISCONNECT. It was a plain field, so `save()`'s `GSON.toJson(this, ...)` wrote it to `freeLook.json`.

`load()` never reads it back (it only copies `perspective`, `isToggle`, `maxHeadYaw`, `blockList`), so this caused no functional bug — but persisting runtime state to the config file is incorrect and confusing.

Marking it `transient` makes Gson skip it in both directions. Leftover `"isBlocked"` keys in existing config files are ignored on load and dropped on the next save.

Complements #46 (which made the JOIN handler authoritative for clearing stale in-session block state).