### PR TITLE
Update to Minecraft 26.2 + open issue on auto-update build failure

### DIFF
--- a/.github/workflows/update-minecraft.yml
+++ b/.github/workflows/update-minecraft.yml
@@ -90,11 +90,51 @@ jobs:
           grep -E '^(minecraft|loader|fabric|mod)_version=' gradle.properties
 
       - name: Build
+        id: build
         if: steps.check.outputs.needed == 'true'
-        run: ./gradlew build --no-daemon
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ./gradlew build --no-daemon 2>&1 | tee build.log
+
+      - name: Open issue on build failure
+        if: steps.check.outputs.needed == 'true' && steps.build.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MC="${{ steps.latest_mc.outputs.version }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TITLE="Auto-update to Minecraft $MC failed to build"
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Issue already open: #$EXISTING — skipping."
+            exit 0
+          fi
+
+          ERRORS=$(grep -E "error:|cannot find symbol|Compilation failed|> Task .* FAILED" build.log | head -40 || true)
+
+          gh issue create \
+            --title "$TITLE" \
+            --body "Automated Minecraft update to \`$MC\` could not build — likely an API/mapping change needing manual source fixes.
+
+          | Property | Value |
+          |---|---|
+          | Minecraft | \`$MC\` |
+          | Fabric Loader | \`${{ steps.fabric.outputs.loader }}\` |
+          | Fabric API | \`${{ steps.fabric.outputs.api }}\` |
+
+          [Failed workflow run]($RUN_URL)
+
+          <details><summary>Build error excerpt</summary>
+
+          \`\`\`
+          $ERRORS
+          \`\`\`
+          </details>"
 
       - name: Create PR
-        if: steps.check.outputs.needed == 'true'
+        if: steps.check.outputs.needed == 'true' && steps.build.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -123,3 +163,9 @@ jobs:
           Build passed. ✓" \
             --base master \
             --head "$BRANCH"
+
+      - name: Fail job if build failed
+        if: steps.check.outputs.needed == 'true' && steps.build.outcome == 'failure'
+        run: |
+          echo "Build failed for the auto-update; an issue was opened. Failing the job."
+          exit 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,15 +7,15 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=26.1.2
-loader_version=0.19.2
+minecraft_version=26.2
+loader_version=0.19.3
 loom_version=1.15-SNAPSHOT
 
 # Fabric API
-fabric_version=0.150.0+26.1.2
+fabric_version=0.152.1+26.2
 
 # Mod Properties
-mod_version=1.4.1
+mod_version=1.4.2
 maven_group=freelook
 archives_base_name=freelook
 

--- a/src/main/java/freelook/freelook/DisabledServerScreen.java
+++ b/src/main/java/freelook/freelook/DisabledServerScreen.java
@@ -57,7 +57,7 @@ public class DisabledServerScreen extends Screen {
 
         this.addRenderableWidget(new Button.Builder(Component.translatable("gui.back"), button -> {
             assert this.minecraft != null;
-            this.minecraft.setScreen(parent);
+            this.minecraft.setScreenAndShow(parent);
         }).bounds(centerX - 100, this.height - 40, 200, 20).build());
     }
 

--- a/src/main/java/freelook/freelook/FreeLookMod.java
+++ b/src/main/java/freelook/freelook/FreeLookMod.java
@@ -68,7 +68,7 @@ public class FreeLookMod implements ClientModInitializer {
     private void onTickEnd(Minecraft client) {
         if (freeLookScreenKeyBind.consumeClick()) {
             Screen screen = new FreelookScreen();
-            client.setScreen(screen);
+            client.setScreenAndShow(screen);
         }
         if (!config.isBlocked()) {
             if (!config.isToggle()) {

--- a/src/main/java/freelook/freelook/FreelookScreen.java
+++ b/src/main/java/freelook/freelook/FreelookScreen.java
@@ -80,7 +80,7 @@ public class FreelookScreen extends Screen {
 
         this.addRenderableWidget(new Button.Builder(Component.translatable("freelook.menu.disabled_servers"), button -> {
             assert this.minecraft != null;
-            this.minecraft.setScreen(new DisabledServerScreen(this));
+            this.minecraft.setScreenAndShow(new DisabledServerScreen(this));
         }).bounds(centerX - 100, baseY + 3 * lineHeight, 200, 20).build());
 
 


### PR DESCRIPTION
## Minecraft 26.2
26.2 renamed `Minecraft.setScreen(Screen)` → `setScreenAndShow(Screen)` (verified via `javap` on the resolved 26.2 jar). Migrated 3 call sites:
- `FreeLookMod.java:71`
- `DisabledServerScreen.java:60`
- `FreelookScreen.java:83`

Version bump in `gradle.properties`: mc `26.2`, loader `0.19.3`, fabric api `0.152.1+26.2`, mod `1.4.2`. `./gradlew build` passes locally.

## Auto-update workflow hardening
The daily updater silently skipped PR creation when a new MC version broke the build (e.g. this very mapping change). Now:
- **Build failure opens a deduplicated issue** with versions, run link, and error excerpt.
- PR creation gated on build success.
- Run still marked red on failure so breakage is visible.

Flow: bump → build → pass ⇒ PR / fail ⇒ open issue + red run.