### PR TITLE
Auto-publish to Modrinth/CurseForge + keep fabric.mod.json in sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish
+
+# Fully automatic: publishes whenever gradle.properties lands on master with a
+# mod_version that has not been released yet (e.g. after the auto-update PR is
+# merged). Guarded by a git tag so re-runs / unrelated edits never double-publish.
+on:
+  push:
+    branches: [master]
+    paths:
+      - gradle.properties
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the version tag + GitHub release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need tags to detect already-published versions
+
+      - name: Read versions
+        id: vars
+        run: |
+          MOD=$(grep '^mod_version=' gradle.properties | cut -d= -f2)
+          MC=$(grep '^minecraft_version=' gradle.properties | cut -d= -f2)
+          echo "mod=$MOD" >> $GITHUB_OUTPUT
+          echo "mc=$MC" >> $GITHUB_OUTPUT
+          echo "tag=v$MOD" >> $GITHUB_OUTPUT
+
+      - name: Skip if version already published
+        id: guard
+        run: |
+          if git rev-parse "refs/tags/${{ steps.vars.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.vars.outputs.tag }} exists — already published. Skipping."
+            echo "publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "publish=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Java
+        if: steps.guard.outputs.publish == 'true'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Build
+        if: steps.guard.outputs.publish == 'true'
+        run: ./gradlew build --no-daemon
+
+      - name: Publish to Modrinth & CurseForge
+        if: steps.guard.outputs.publish == 'true'
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: freelook
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          # TODO: replace with the numeric CurseForge project id (Project page → "About" → Project ID)
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          name: Freelook ${{ steps.vars.outputs.mod }} for ${{ steps.vars.outputs.mc }}
+          version: ${{ steps.vars.outputs.mod }}
+          version-type: release
+          loaders: fabric
+          game-versions: ${{ steps.vars.outputs.mc }}
+          dependencies: |
+            fabric-api
+          files: build/libs/!(*-sources).jar
+
+      - name: Tag and GitHub release
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          JAR=$(ls build/libs/*.jar | grep -vE '(-sources|-dev|-shadow)\.jar$' | head -1)
+          git tag "${{ steps.vars.outputs.tag }}"
+          git push origin "${{ steps.vars.outputs.tag }}"
+          gh release create "${{ steps.vars.outputs.tag }}" \
+            --title "Freelook ${{ steps.vars.outputs.mod }} (MC ${{ steps.vars.outputs.mc }})" \
+            --notes "Automated release for Minecraft ${{ steps.vars.outputs.mc }}." \
+            "$JAR"

--- a/.github/workflows/update-minecraft.yml
+++ b/.github/workflows/update-minecraft.yml
@@ -86,8 +86,14 @@ jobs:
           sed -i "s/^fabric_version=.*/fabric_version=$API/" gradle.properties
           sed -i "s/^mod_version=.*/mod_version=$MOD/" gradle.properties
 
+          # Keep fabric.mod.json's minecraft dependency in sync (major.minor, e.g. 26.2.1 -> ~26.2)
+          MM=$(echo "$MC" | cut -d. -f1,2)
+          sed -i "s/\"minecraft\": *\"[^\"]*\"/\"minecraft\": \"~$MM\"/" src/main/resources/fabric.mod.json
+
           echo "Updated gradle.properties:"
           grep -E '^(minecraft|loader|fabric|mod)_version=' gradle.properties
+          echo "Updated fabric.mod.json minecraft dependency:"
+          grep '"minecraft"' src/main/resources/fabric.mod.json
 
       - name: Build
         id: build
@@ -145,7 +151,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add gradle.properties
+          git add gradle.properties src/main/resources/fabric.mod.json
           git commit -m "Update project to Minecraft $MC (v$MOD)"
           git push origin "$BRANCH"
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.18.4",
-    "minecraft": "~26.1",
+    "minecraft": "~26.2",
     "fabric-api": "*",
     "fabric-key-mapping-api-v1": "*"
   }


### PR DESCRIPTION
## Auto-publish (`publish.yml`)
Push to master that bumps `mod_version` (e.g. after the auto-update PR merges) → build → publish to **Modrinth + CurseForge** via `mc-publish` → tag + GitHub release. A `v<version>` tag guards against double-publishing; the build runs in-job so a broken build never publishes.

**Setup required before this works** (repo Settings):
- Secret `MODRINTH_TOKEN` — Modrinth PAT, `Create versions` scope only
- Secret `CURSEFORGE_TOKEN` + variable `CURSEFORGE_PROJECT_ID` — needs a CurseForge project to exist first

Modrinth-only? Drop the two `curseforge-*` lines.

## fabric.mod.json sync
- `depends.minecraft` was stale at `~26.1`; corrected to `~26.2`.
- `update-minecraft.yml` now bumps `depends.minecraft` to `~<major.minor>` alongside `gradle.properties` and commits it, so it self-maintains on future updates.

## Security notes
- `publish.yml` triggers on `push` only — no fork/`pull_request_target` secret exposure.
- File contains secret *names*, never values.
- master is now branch-protected (PR + 1 approval, no force-push/deletion).