### PR TITLE
Step auto-updates one MC version at a time

### DIFF
--- a/.github/workflows/update-minecraft.yml
+++ b/.github/workflows/update-minecraft.yml
@@ -27,11 +27,17 @@ jobs:
           echo "mc=$(grep '^minecraft_version=' gradle.properties | cut -d= -f2)" >> $GITHUB_OUTPUT
           echo "mod=$(grep '^mod_version=' gradle.properties | cut -d= -f2)" >> $GITHUB_OUTPUT
 
-      - name: Fetch latest stable Minecraft version
+      - name: Fetch next stable Minecraft version
         id: latest_mc
         run: |
+          # Step one version at a time (not straight to newest) so that when we are
+          # several versions behind, each intermediate version gets built & published.
+          # The list is newest-first, so "next after current" = the entry before it.
           LATEST=$(curl -sf https://meta.fabricmc.net/v2/versions/game | \
-            jq -r '[.[] | select(.stable == true)] | first | .version')
+            jq -r --arg cur "${{ steps.current.outputs.mc }}" \
+              '[.[] | select(.stable == true) | .version] as $v |
+               ($v | index($cur)) as $i |
+               if $i == null or $i == 0 then $v[0] else $v[$i - 1] end')
           echo "version=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Check if update needed


### PR DESCRIPTION
The daily updater jumped straight to the newest stable Minecraft version, so if the repo fell 2+ versions behind, skipped versions never got a published build.

Now it targets the *next* stable version after the current one (Fabric meta list is newest-first, so next = the entry before current). Each daily run steps up one version, opens its PR, and merging it triggers the publish hook — so every intermediate version gets released.

When already on latest, the selector returns the current version and the existing "no update needed" check short-circuits, unchanged.

Verified the jq locally: cur=26.1 → 26.1.1, cur=26.2 → 26.2.